### PR TITLE
Ensure routeid protection works even if no session cookie is present

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,13 +8,10 @@ export const authHandle: Handle = async ({ event, resolve }) => {
 	event.locals.startTimer = startTimer;
 
 	const sessionId = event.cookies.get(lucia.sessionCookieName);
-	if (!sessionId) {
-		event.locals.user = null;
-		event.locals.session = null;
-		return resolve(event);
-	}
+	const { session, user } = sessionId
+		? await lucia.validateSession(sessionId)
+		: { session: null, user: null };
 
-	const { session, user } = await lucia.validateSession(sessionId);
 	if (session && session.fresh) {
 		const sessionCookie = lucia.createSessionCookie(session.id);
 		event.cookies.set(sessionCookie.name, sessionCookie.value, {


### PR DESCRIPTION
If there is no session cookie, the request is beeing processed without an auth check.
Since the auth is not checked in the `update` action in `src/routes/(private)/(admin)/users
/+page.server.ts` either, you can modify users without beeing logged in.